### PR TITLE
Removing a song from the playlist resets the lockOrder to zero

### DIFF
--- a/api/songs/respository/song-repository-lock.int.test.ts
+++ b/api/songs/respository/song-repository-lock.int.test.ts
@@ -26,4 +26,20 @@ describe("The song repository with lock order", () => {
     expect(matches.page[1].id).toBe(SongIds.song4Id);
     expect(matches.page[2].id).toBe(SongIds.song3Id);
     });
+
+    it("clears lockOrder when song is removed from playlist", async () => {
+      const songRepository = createSongRepository(dynamo.client());
+      await songRepository.clearVotes(SongIds.song5Id);
+
+      const songRecord = await dynamo.client().getItem({
+        Key: {
+          PK: Songs.song5.Item.PK,
+          SK: Songs.song5.Item.SK,
+        },
+        TableName: "song",
+      });
+
+      expect(songRecord).toBeDefined();
+      expect(songRecord.Item?.["lockOrder"].N).toEqual("0");
+    });
 });

--- a/api/songs/respository/song-repository.ts
+++ b/api/songs/respository/song-repository.ts
@@ -228,8 +228,11 @@ export const createSongRepository = (client: DynamoDB) => {
         ":voteCount": {
           N: "0",
         },
+        ":lockOrder": {
+          N: "0",
+        },
       },
-      UpdateExpression: "SET voteCount = :voteCount REMOVE GSI2PK, voters",
+      UpdateExpression: "SET voteCount = :voteCount, lockOrder = :lockOrder REMOVE GSI2PK, voters",
     });
     // throw "NYI: need to remove votes";
   };


### PR DESCRIPTION
When an admin removes a song from the playlist, `clearVotes` now resets `lockOrder` to 0. This should keep the song from automatically pinning to the top of the list if someone votes for it again.